### PR TITLE
Use `zlib` instead of `zlib-gabi`

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,2 @@
 [target."x86_64-unknown-linux-gnu"]
-rustflags = ["-C", "link-arg=-Wl,--compress-debug-sections=zlib-gabi"]
+rustflags = ["-C", "link-arg=-Wl,--compress-debug-sections=zlib"]


### PR DESCRIPTION
According to https://maskray.me/blog/2022-01-23-compressed-debug-sections :

> Nowadays just use zlib and avoid zlib-gabi.

Just through it might be worth bring up. I'm going to try it in my projects.